### PR TITLE
working but not full-featured gift reload ability

### DIFF
--- a/src/i18n/home/en.json
+++ b/src/i18n/home/en.json
@@ -30,6 +30,10 @@
       "title": "Want your money back?",
       "instructions": "You can send all the BCH from your unclaimed gifts to a single address in one transaction."
     },
+    "reload": {
+      "title": "Want to reload your claimed Gifts?",
+      "instructions": "You can reload any already-claimed gifts with the same amount of original BCH. However, these gifts will not be reclaimed automatically. You will need to manually reclaim your funds using this dashboard or the mnemonic seed."
+    },
     "manage": {
       "title": "Manage Gifts",
       "claimedCount": "{tipsClaimedCount} of {tipsTotalCount} gifts have been claimed"
@@ -70,6 +74,7 @@
     "jpg": "JPG",
     "wif": "WIF",
     "address": "Address",
+    "copyAddr": "Copy Address",
     "youGot": "You have received",
     "on": "on",
     "claimBy": "Claim by",
@@ -110,6 +115,8 @@
   },
   "buttons": {
     "createTips": "Go",
+    "reloadGifts": "Reload Claimed Gifts",
+    "moarReloading": "Reload Again",
     "goBack": "Back",
     "copyUri": "Copy URI",
     "copySeed": "Copy",
@@ -152,6 +159,7 @@
   },
   "errors": {
     "tipCountNoTips": "Gift count must be greater than zero",
+    "nothingToReload": "Error generating reload invoice: No empty gifts",
     "tipCountNotInteger": "Gift count must be an integer",
     "tipCountNum": "Gift count must be a number",
     "fiatTipAmountNum": "Gift amount in local currency must be a number",

--- a/src/views/Home/GiftsPortal/Gift/Gift.js
+++ b/src/views/Home/GiftsPortal/Gift/Gift.js
@@ -54,6 +54,7 @@ import {
   LoadingButton,
   ShareMenuButton,
   ShareMenuButtonCopy,
+  ClaimedCopy,
   ShareMenuButtonEmail,
   LogoFooter,
   InputError,
@@ -706,6 +707,13 @@ const Gift = ({
             </tr>
           </tbody>
         </StatusTable>
+        {tipWallet.status === 'claimed' && (
+          <CopyToClipboard text={tipWallet.addr} onCopy={addrCopied}>
+            <ClaimedCopy type="button">
+              <FormattedMessage id="home.gift.copyAddr" />
+            </ClaimedCopy>
+          </CopyToClipboard>
+        )}
         {tipWallet.status === 'unclaimed' && (
           <ShareMenu
             trigger={

--- a/src/views/Home/GiftsPortal/Gift/styled.js
+++ b/src/views/Home/GiftsPortal/Gift/styled.js
@@ -114,6 +114,20 @@ export const ShareMenuButtonPDF = styled.button`
     color: #000;
   }
 `;
+export const ClaimedCopy = styled.button`
+  width: 130px;
+  text-align: right;
+  float: right;
+  z-index: 10;
+  outline: none;
+  padding: 12px;
+  color: #4d4d4d;
+  cursor: pointer;
+  background-color: transparent;
+  background: url(${copypaste}) no-repeat 8px center;
+  border: none;
+  height: 100%;
+`;
 export const ShareMenuButtonCopy = styled.button`
   width: 100%;
   z-index: 10;


### PR DESCRIPTION
Added feature to reload claimed gifts.

### Background

This feature was requested after a user printed and posted stickers around a public place, and then wished to reload these gifts without having to reprint and repost. 

### Summary

This is the simplest implementation. The app scans the balance of gifts and determines if any have been swept. If they have, it creates a BIP70 invoice to refill them with the original amount of BCH (to match what is printed on the ticket). This does not interact with the back end at all. Gifts that have been reloaded will not be automatically returned. They must be claimed or manually swept from the dashboard.

### Features

- Copy Address option for claimed gifts
- Reload gifts option
- Can reload gifts repeatedly as long as at least 1 gift has a 0 balance