### PR TITLE
Disable bip70 gift reloading

### DIFF
--- a/src/i18n/home/en.json
+++ b/src/i18n/home/en.json
@@ -74,7 +74,7 @@
     "jpg": "JPG",
     "wif": "WIF",
     "address": "Address",
-    "copyAddr": "Copy Address",
+    "copyAddr": "Copy Addr",
     "youGot": "You have received",
     "on": "on",
     "claimBy": "Claim by",

--- a/src/views/Home/GiftsPortal/Gift/styled.js
+++ b/src/views/Home/GiftsPortal/Gift/styled.js
@@ -115,7 +115,7 @@ export const ShareMenuButtonPDF = styled.button`
   }
 `;
 export const ClaimedCopy = styled.button`
-  width: 130px;
+  width: 80px;
   text-align: right;
   float: right;
   z-index: 10;

--- a/src/views/Home/GiftsPortal/GiftsPortal.js
+++ b/src/views/Home/GiftsPortal/GiftsPortal.js
@@ -3817,16 +3817,15 @@ class GiftsPortal extends React.Component {
                 </>
               )}
             </ShowCard>
-            <ShowCard
-              padded
-              centered
-              className="noPrint"
-              show={
+            {/* Hiding this card even though the code works due to risk of users losing funds, as reloaded gifts do not have reclaim txs
+             To show, the show parameter in ShowCard should be
+             show={
                 importedGiftInfo.length > 0 &&
                 typeof importedGiftInfo[0].fiatCode !== 'undefined' &&
                 typeof importedGiftInfo[0].fiatAmount !== 'undefined'
               }
-            >
+             */}
+            <ShowCard padded centered className="noPrint" show={false}>
               <H3>
                 <FormattedMessage id="home.cards.reload.title" />
               </H3>


### PR DESCRIPTION
- Style fixes for "copy address" feature on claimed Gifts
- Hiding the Bip70 workflow for reloading gifts added in #36 with comments

This feature can be added in the future, but I think the risks outweigh the benefits unless

- It's more customizable
- It works with the backend (new auto-refund txs)