### PR TITLE
fix broken icon img

### DIFF
--- a/src/views/Home/GiftsPortal/Gift/Gift.js
+++ b/src/views/Home/GiftsPortal/Gift/Gift.js
@@ -646,7 +646,19 @@ const Gift = ({
                     <FormattedMessage id="home.gift.stepOne" />
                   </StepOneOG>
                   <StepTwoOG>
-                    <FormattedMessage id="home.gift.stepTwo" />
+                    <FormattedMessage
+                      id="home.gift.stepTwo"
+                      values={{
+                        scanner: (
+                          <img
+                            src={sweepIconOG}
+                            alt=""
+                            width="16px"
+                            style={{ padding: '0 5px' }}
+                          />
+                        ),
+                      }}
+                    />
                   </StepTwoOG>
                   <StepThreeOG>
                     <FormattedMessage id="home.gift.stepThree" />


### PR DESCRIPTION
broken icon img on "easy print" theme:
![IMAGE 2021-10-15 10_13_59](https://user-images.githubusercontent.com/65150922/137574059-0b005812-8384-4d6c-9767-cfb57767220e.jpg)

fixed:
<img width="333" alt="Screen Shot 2021-10-15 at 9 44 05 PM" src="https://user-images.githubusercontent.com/65150922/137574066-5548a5b7-efc4-4983-b37a-6c2577e9d1fa.png">


